### PR TITLE
Device wasi_nn for AI inference 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ compile:
 
 WAMR_VERSION = 2.2.0
 WAMR_DIR = _build/wamr
+WASI_NN_DIR = _build/wasi_nn/wasi_nn_backend
 
 GENESIS_WASM_BRANCH = tillathehun0/cu-experimental
 GENESIS_WASM_REPO = https://github.com/permaweb/ao.git
@@ -104,3 +105,19 @@ setup-genesis-wasm: $(GENESIS_WASM_SERVER_DIR)
 	fi
 	@cd $(GENESIS_WASM_SERVER_DIR) && npm install > /dev/null 2>&1 && \
 		echo "Installed genesis-wasm@1.0 server."
+# Set up wasi-nn environment
+$(WASI_NN_DIR):
+	@echo "Cloning wasi-nn backend repository..." && \
+	git clone --depth=1 -b stage/wasi-nn https://github.com/apuslabs/wasi_nn_backend.git $(WASI_NN_DIR) && \
+	echo "Cloned wasi-nn backend to $(WASI_NN_DIR)"
+
+setup-wasi-nn: $(WASI_NN_DIR)
+	@mkdir -p $(WASI_NN_DIR)/lib
+	@echo "Building wasi-nn backend..." && \
+	cmake \
+		$(WAMR_FLAGS) \
+		-S $(WASI_NN_DIR) \
+		-B $(WASI_NN_DIR)/build && \
+	make -C $(WASI_NN_DIR)/build -j8 && \
+	cp $(WASI_NN_DIR)/build/libwasi_nn_backend.so ./native/wasi_nn_llama && \
+	echo "Successfully built wasi-nn backend"

--- a/native/wasi_nn_llama/include/wasi_nn_llama.h
+++ b/native/wasi_nn_llama/include/wasi_nn_llama.h
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) 2019 Intel Corporation.  All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ */
+
+ #ifndef WASI_NN_TYPES_H
+ #define WASI_NN_TYPES_H
+ 
+#include <stdint.h>
+#include <stdbool.h>
+
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+ 
+ /**
+  * ERRORS
+  *
+  */
+ 
+ // sync up with
+ // https://github.com/WebAssembly/wasi-nn/blob/main/wit/wasi-nn.wit#L136 Error
+ // codes returned by functions in this API.
+ typedef enum {
+	 // No error occurred.
+	 success = 0,
+	 // Caller module passed an invalid argument.
+	 invalid_argument,
+	 // Invalid encoding.
+	 invalid_encoding,
+	 // The operation timed out.
+	 timeout,
+	 // Runtime Error.
+	 runtime_error,
+	 // Unsupported operation.
+	 unsupported_operation,
+	 // Graph is too large.
+	 too_large,
+	 // Graph not found.
+	 not_found,
+	 // The operation is insecure or has insufficient privilege to be performed.
+	 // e.g., cannot access a hardware feature requested
+	 security,
+	 // The operation failed for an unspecified reason.
+	 unknown,
+	 // for WasmEdge-wasi-nn
+	 end_of_sequence = 100,  // End of Sequence Found.
+	 context_full = 101,     // Context Full.
+	 prompt_tool_long = 102, // Prompt Too Long.
+	 model_not_found = 103,  // Model Not Found.
+ } wasi_nn_error;
+ 
+ /**
+  * TENSOR
+  *
+  */
+ 
+ // The dimensions of a tensor.
+ //
+ // The array length matches the tensor rank and each element in the array
+ // describes the size of each dimension.
+ typedef struct {
+	 uint32_t *buf;
+	 uint32_t size;
+ } tensor_dimensions;
+ 
+ #if WASM_ENABLE_WASI_EPHEMERAL_NN != 0
+ // sync up with
+ // https://github.com/WebAssembly/wasi-nn/blob/main/wit/wasi-nn.wit#L27
+ // The type of the elements in a tensor.
+ typedef enum { fp16 = 0, fp32, fp64, bf16, u8, i32, i64 } tensor_type;
+ #else
+ typedef enum { fp16 = 0, fp32, up8, ip32 } tensor_type;
+ #endif /* WASM_ENABLE_WASI_EPHEMERAL_NN != 0 */
+ 
+ // The tensor data.
+ //
+ // Initially conceived as a sparse representation, each empty cell would be
+ // filled with zeros and the array length must match the product of all of the
+ // dimensions and the number of bytes in the type (e.g., a 2x2 tensor with
+ // 4-byte f32 elements would have a data array of length 16). Naturally, this
+ // representation requires some knowledge of how to lay out data in
+ // memory--e.g., using row-major ordering--and could perhaps be improved.
+ typedef uint8_t *tensor_data;
+ 
+ // A tensor.
+ typedef struct {
+	 // Describe the size of the tensor (e.g., 2x2x2x2 -> [2, 2, 2, 2]). To
+	 // represent a tensor containing a single value, use `[1]` for the tensor
+	 // dimensions.
+	 tensor_dimensions *dimensions;
+	 // Describe the type of element in the tensor (e.g., f32).
+	 tensor_type type;
+	 // Contains the tensor data.
+	 tensor_data data;
+ } tensor;
+ 
+ /**
+  * GRAPH
+  *
+  */
+ 
+ // The graph initialization data.
+ //
+ // This consists of an array of buffers because implementing backends may encode
+ // their graph IR in parts (e.g., OpenVINO stores its IR and weights
+ // separately).
+ typedef struct {
+	 uint8_t *buf;
+	 uint32_t size;
+ } graph_builder;
+ 
+ typedef struct {
+	 graph_builder *buf;
+	 uint32_t size;
+ } graph_builder_array;
+ 
+ // An execution graph for performing inference (i.e., a model).
+ typedef uint32_t graph;
+ 
+ // sync up with
+ // https://github.com/WebAssembly/wasi-nn/blob/main/wit/wasi-nn.wit#L75
+ // Describes the encoding of the graph. This allows the API to be implemented by
+ // various backends that encode (i.e., serialize) their graph IR with different
+ // formats.
+ typedef enum {
+	 openvino = 0,
+	 onnx,
+	 tensorflow,
+	 pytorch,
+	 tensorflowlite,
+	 ggml,
+	 autodetect,
+	 unknown_backend,
+ } graph_encoding;
+ 
+ // Define where the graph should be executed.
+ typedef enum execution_target { cpu = 0, gpu, tpu } execution_target;
+ 
+ // Bind a `graph` to the input and output tensors for an inference.
+ typedef uint32_t graph_execution_context;
+ 
+
+ __attribute__((visibility("default"))) wasi_nn_error
+ init_backend(void **ctx) ;
+
+ __attribute__((visibility("default"))) wasi_nn_error
+ init_backend_with_config(void **ctx, const char *config, uint32_t config_len);
+ 
+ __attribute__((visibility("default"))) wasi_nn_error
+ deinit_backend(void *ctx);
+
+ __attribute__((visibility("default"))) wasi_nn_error
+ load_by_name_with_config(void *ctx, const char *filename, uint32_t filename_len,
+	const char *config, uint32_t config_len, graph *g);
+
+ __attribute__((visibility("default"))) wasi_nn_error
+ init_execution_context(void *ctx, const char *session_id, graph_execution_context *exec_ctx);
+
+ __attribute__((visibility("default"))) wasi_nn_error
+ close_execution_context(void *ctx, graph_execution_context exec_ctx);
+ 
+ __attribute__((visibility("default"))) wasi_nn_error
+ run_inference(void *ctx, graph_execution_context exec_ctx, uint32_t index,
+		   tensor *input_tensor,tensor_data output_tensor, uint32_t *output_tensor_size, const char *options);
+
+ __attribute__((visibility("default"))) wasi_nn_error
+ set_input(void *ctx, graph_execution_context exec_ctx, uint32_t index,
+	  tensor *wasi_nn_tensor);
+ 
+ __attribute__((visibility("default"))) wasi_nn_error
+ compute(void *ctx, graph_execution_context exec_ctx);
+ 
+ __attribute__((visibility("default"))) wasi_nn_error
+ get_output(void *ctx, graph_execution_context exec_ctx, uint32_t index,
+	  tensor_data output_tensor, uint32_t *output_tensor_size);
+
+ 
+ #ifdef __cplusplus
+ }
+ #endif
+ #endif
+ 

--- a/native/wasi_nn_llama/include/wasi_nn_logging.h
+++ b/native/wasi_nn_llama/include/wasi_nn_logging.h
@@ -1,0 +1,34 @@
+#include <pthread.h>
+#include <stdarg.h>
+#include <string.h>
+#include <time.h>
+#ifndef HB_LOGGING_H
+#define HB_LOGGING_H
+
+
+// Enable debug logging by default if not defined
+#define HB_DEBUG 0
+#ifndef HB_DEBUG
+#endif
+
+
+#define DRV_DEBUG(format, ...) beamr_print(HB_DEBUG, __FILE__, __LINE__, format, ##__VA_ARGS__)
+#define DRV_PRINT(format, ...) beamr_print(1, __FILE__, __LINE__, format, ##__VA_ARGS__)
+
+/*
+ * Function: beamr_print
+ * --------------------
+ * This function prints a formatted message to the standard output, prefixed with the thread
+ * ID, file name, and line number where the log was generated.
+ * 
+ *  print: A flag that controls whether the message is printed (1 to print, 0 to skip).
+ *  file: The source file name where the log was generated.
+ *  line: The line number where the log was generated.
+ *  format: The format string for the message.
+ *  ...: The variables to be printed in the format.
+ */
+void beamr_print(int print, const char* file, int line, const char* format, ...);
+
+
+
+#endif // HB_LOGGING_H

--- a/native/wasi_nn_llama/include/wasi_nn_nif.h
+++ b/native/wasi_nn_llama/include/wasi_nn_nif.h
@@ -1,0 +1,40 @@
+#ifndef WASI_NN_NIF_H
+#define WASI_NN_NIF_H
+
+#include "wasi_nn_llama.h"
+#include <erl_nif.h>
+#include <stdio.h>
+#include <string.h>
+#include <dlfcn.h>
+
+
+// Function pointer types
+typedef wasi_nn_error (*init_backend_fn)(void **ctx);
+typedef wasi_nn_error (*init_backend_with_config_fn)(void **ctx, const char *config, uint32_t config_len);
+typedef wasi_nn_error (*deinit_backend_fn)(void *ctx);
+typedef wasi_nn_error (*init_execution_context_fn)(void *ctx, const char *session_id, graph_execution_context *exec_ctx);
+typedef wasi_nn_error (*close_execution_context_fn)(void *ctx, graph_execution_context exec_ctx);
+typedef wasi_nn_error (*load_by_name_with_config_fn)(void *ctx, const char *filename, uint32_t filename_len,
+	const char *config, uint32_t config_len, graph *g);
+typedef wasi_nn_error (*run_inference_fn)(void *ctx, graph_execution_context exec_ctx, uint32_t index,
+	tensor *input_tensor,tensor_data output_tensor, uint32_t *output_tensor_size, const char *options);
+typedef wasi_nn_error (*set_input_fn)(void *ctx, graph_execution_context exec_ctx, uint32_t index, tensor *tensor);
+typedef wasi_nn_error (*compute_fn)(void *ctx, graph_execution_context exec_ctx);
+typedef wasi_nn_error (*get_output_fn)(void *ctx, graph_execution_context exec_ctx, uint32_t index, tensor_data output, uint32_t *output_size);
+
+// Structure to hold all function pointers
+typedef struct {
+    void* handle;
+    init_backend_fn init_backend;
+    init_backend_with_config_fn init_backend_with_config;
+    deinit_backend_fn deinit_backend;
+	load_by_name_with_config_fn load_by_name_with_config;
+    init_execution_context_fn init_execution_context;
+    close_execution_context_fn close_execution_context;
+	run_inference_fn run_inference;
+    set_input_fn set_input;
+    compute_fn compute;
+    get_output_fn get_output;
+
+} wasi_nn_backend_api;
+#endif // WASI_NN_NIF_H

--- a/native/wasi_nn_llama/src/wasi_nn_logging.c
+++ b/native/wasi_nn_llama/src/wasi_nn_logging.c
@@ -1,0 +1,36 @@
+#include "../include/wasi_nn_logging.h"
+
+
+
+void beamr_print(int print, const char* file, int line, const char* format, ...) {
+    va_list args;
+    va_start(args, format);
+    if(print) {
+        pthread_t thread_id = pthread_self();
+        printf("[DBG#%p @ %s:%d] ", thread_id, file, line);
+        vprintf(format, args);
+        printf("\r\n");
+    }
+    va_end(args);
+}
+
+// void send_error(Proc* proc, const char* message_fmt, ...) {
+//     va_list args;
+//     va_start(args, message_fmt);
+//     char* message = driver_alloc(256);
+//     vsnprintf(message, 256, message_fmt, args);
+//     DRV_DEBUG("Sending error message: %s", message);
+//     ErlDrvTermData* msg = driver_alloc(sizeof(ErlDrvTermData) * 7);
+//     int msg_index = 0;
+//     msg[msg_index++] = ERL_DRV_ATOM;
+//     msg[msg_index++] = atom_error;
+//     msg[msg_index++] = ERL_DRV_STRING;
+//     msg[msg_index++] = (ErlDrvTermData)message;
+//     msg[msg_index++] = strlen(message);
+//     msg[msg_index++] = ERL_DRV_TUPLE;
+//     msg[msg_index++] = 2;
+
+//     int msg_res = erl_drv_output_term(proc->port_term, msg, msg_index);
+//     DRV_DEBUG("Sent error message. Res: %d", msg_res);
+//     va_end(args);
+// }

--- a/native/wasi_nn_llama/src/wasi_nn_nif.c
+++ b/native/wasi_nn_llama/src/wasi_nn_nif.c
@@ -1,0 +1,292 @@
+#include "../include/wasi_nn_nif.h"
+#include "../include/wasi_nn_logging.h"
+#define LIB_PATH "./native/wasi_nn_llama/libwasi_nn_backend.so"
+#define MAX_MODEL_PATH 256
+#define MAX_INPUT_SIZE 4096
+#define MAX_CONFIG_SIZE 1024
+#define MAX_OUTPUT_SIZE 8192
+
+typedef struct {
+    void* ctx;
+    graph g;
+    graph_execution_context exec_ctx;
+} LlamaContext;
+
+static wasi_nn_backend_api g_wasi_nn_functions = {0};
+static ErlNifResourceType* llama_context_resource;
+
+static void llama_context_destructor(ErlNifEnv* env, void* obj)
+{
+
+    LlamaContext* ctx = (LlamaContext*)obj;
+    if (ctx) {
+        // Cleanup backend context
+        if (ctx->ctx && g_wasi_nn_functions.deinit_backend) {
+            g_wasi_nn_functions.deinit_backend(ctx->ctx);
+            ctx->ctx = NULL;
+        }
+        // No need to cleanup shared library here since it's managed globally
+        // Clear the context structure
+        memset(ctx, 0, sizeof(LlamaContext));
+    }
+
+}
+
+static int load(ErlNifEnv* env, void** priv_data, ERL_NIF_TERM load_info)
+{
+    DRV_DEBUG("Load nif start\n");
+	g_wasi_nn_functions.handle = dlopen(LIB_PATH, RTLD_LAZY);
+    if (!g_wasi_nn_functions.handle) {
+        DRV_DEBUG("Failed to load wasi library: %s\n", dlerror());
+        return 1;
+    }
+	// Load all required functions once
+	g_wasi_nn_functions.init_backend = (init_backend_fn)dlsym(g_wasi_nn_functions.handle, "init_backend");
+    g_wasi_nn_functions.init_backend_with_config = (init_backend_with_config_fn)dlsym(g_wasi_nn_functions.handle, "init_backend_with_config");
+    g_wasi_nn_functions.deinit_backend = (deinit_backend_fn)dlsym(g_wasi_nn_functions.handle, "deinit_backend");
+    g_wasi_nn_functions.init_execution_context = (init_execution_context_fn)dlsym(g_wasi_nn_functions.handle, "init_execution_context");
+    g_wasi_nn_functions.close_execution_context = (close_execution_context_fn)dlsym(g_wasi_nn_functions.handle, "close_execution_context");
+    g_wasi_nn_functions.set_input = (set_input_fn)dlsym(g_wasi_nn_functions.handle, "set_input");
+    g_wasi_nn_functions.compute = (compute_fn)dlsym(g_wasi_nn_functions.handle, "compute");
+    g_wasi_nn_functions.get_output = (get_output_fn)dlsym(g_wasi_nn_functions.handle, "get_output");
+    g_wasi_nn_functions.load_by_name_with_config = (load_by_name_with_config_fn)dlsym(g_wasi_nn_functions.handle, "load_by_name_with_config");
+	g_wasi_nn_functions.run_inference = (run_inference_fn)dlsym(g_wasi_nn_functions.handle, "run_inference");
+    if (!g_wasi_nn_functions.init_backend ||!g_wasi_nn_functions.deinit_backend  ||
+       !g_wasi_nn_functions.init_execution_context ||!g_wasi_nn_functions.close_execution_context ||
+       !g_wasi_nn_functions.set_input ||!g_wasi_nn_functions.compute ||
+       !g_wasi_nn_functions.get_output	||!g_wasi_nn_functions.load_by_name_with_config ||!g_wasi_nn_functions.run_inference) {
+        dlclose(g_wasi_nn_functions.handle);
+        return 1;
+    }
+	DRV_DEBUG("Load nif Finished\n");
+	llama_context_resource = enif_open_resource_type(env, NULL, "llama_context",
+        llama_context_destructor, ERL_NIF_RT_CREATE | ERL_NIF_RT_TAKEOVER, NULL);
+    return llama_context_resource ? 0 : 1;
+}
+
+
+
+
+static ERL_NIF_TERM nif_init_backend(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    LlamaContext* ctx = enif_alloc_resource(llama_context_resource, sizeof(LlamaContext));
+    if (!ctx) {
+        DRV_DEBUG("Failed to allocate LlamaContext resource\n");
+        return enif_make_tuple2(env, enif_make_atom(env, "error"), 
+                              enif_make_atom(env, "allocation_failed"));
+    }
+	DRV_DEBUG("Initializing backend...\n");
+    wasi_nn_error err = g_wasi_nn_functions.init_backend(&ctx->ctx);
+    if (err != success) {
+        DRV_DEBUG("Backend initialization failed with error: %d\n", err);
+        enif_release_resource(ctx);
+        return enif_make_tuple2(env, enif_make_atom(env, "error"), 
+                              enif_make_atom(env, "init_failed"));
+    }
+	DRV_DEBUG("nif_init_backend finished \n");
+    ERL_NIF_TERM ctx_term = enif_make_resource(env, ctx);
+    return enif_make_tuple2(env, enif_make_atom(env, "ok"), ctx_term);
+}
+static ERL_NIF_TERM nif_load_by_name_with_config(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    LlamaContext* ctx;
+    char *model_path = (char *)malloc(MAX_MODEL_PATH * sizeof(char));
+	char *config = (char *)malloc(MAX_CONFIG_SIZE * sizeof(char));
+	ERL_NIF_TERM ret_term; // Variable to hold the return term
+	// if allocate failed
+	if (!model_path || !config) {
+        DRV_DEBUG("Memory allocation failed for model_path or config\n");
+        free(model_path); // free(NULL) is safe
+        free(config);
+        return enif_make_tuple2(env, enif_make_atom(env, "error"),
+                              enif_make_atom(env, "allocation_failed"));
+    }
+	// Get the context from the first argument
+	if(!enif_get_resource(env, argv[0], llama_context_resource, (void**)&ctx))
+	{
+		DRV_DEBUG("Invalid context\n");
+		ret_term = enif_make_tuple2(env, enif_make_atom(env, "error"), enif_make_atom(env, "invalid_context"));
+        goto cleanup; // Use goto for centralized cleanup
+	}
+	// Get the model path from the second argument
+    if (!enif_get_string(env, argv[1], model_path, MAX_MODEL_PATH, ERL_NIF_LATIN1)) {
+		ret_term = enif_make_tuple2(env, enif_make_atom(env, "error"),enif_make_atom(env, "invalid_model_path"));
+		goto cleanup;
+    }
+	// Get the config from the third argument
+	if (!enif_get_string(env, argv[2], config, MAX_CONFIG_SIZE, ERL_NIF_LATIN1)) {
+        ret_term = enif_make_tuple2(env, enif_make_atom(env, "error"),
+                              enif_make_atom(env, "invalid_config"));
+        goto cleanup;
+    }
+	DRV_DEBUG("Loading model: %s  config : %s\n", model_path, config);
+
+    if (g_wasi_nn_functions.load_by_name_with_config(ctx->ctx, model_path, strlen(model_path),
+                                                   config, strlen(config), &ctx->g) != success) {
+        ret_term = enif_make_tuple2(env, enif_make_atom(env, "error"), enif_make_atom(env, "load_failed"));
+        goto cleanup;
+    }
+
+    ret_term = enif_make_atom(env, "ok");
+
+
+cleanup:
+    free(model_path);
+    free(config);
+    return ret_term;
+}
+
+static ERL_NIF_TERM nif_init_execution_context(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+	DRV_DEBUG("Init context Start \n" );
+    LlamaContext* ctx;
+    char session_id[256];
+    
+    if (!enif_get_resource(env, argv[0], llama_context_resource, (void**)&ctx)) {
+        return enif_make_tuple2(env, enif_make_atom(env, "error"), enif_make_atom(env, "invalid_args_init_execution"));
+    }
+    
+    if (!enif_get_string(env, argv[1], session_id, sizeof(session_id), ERL_NIF_LATIN1)) {
+        return enif_make_tuple2(env, enif_make_atom(env, "error"), enif_make_atom(env, "invalid_session_id"));
+    }
+
+    if (g_wasi_nn_functions.init_execution_context(ctx->ctx, session_id, &ctx->exec_ctx)!= success) {
+        return enif_make_tuple2(env, enif_make_atom(env, "error"), enif_make_atom(env, "init_execution_failed"));
+    }
+	DRV_DEBUG("Init context finished for session: %s\n", session_id);
+	return enif_make_tuple2(env, enif_make_atom(env, "ok"), enif_make_ulong(env, ctx->exec_ctx));
+}
+
+static ERL_NIF_TERM nif_close_execution_context(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    LlamaContext* ctx;
+    unsigned long exec_ctx_id;
+    
+    if (!enif_get_resource(env, argv[0], llama_context_resource, (void**)&ctx)) {
+        return enif_make_tuple2(env, enif_make_atom(env, "error"), enif_make_atom(env, "invalid_args"));
+    }
+    
+    if (!enif_get_ulong(env, argv[1], &exec_ctx_id)) {
+        return enif_make_tuple2(env, enif_make_atom(env, "error"), enif_make_atom(env, "invalid_exec_ctx"));
+    }
+
+    if (g_wasi_nn_functions.close_execution_context(ctx->ctx, (graph_execution_context)exec_ctx_id) != success) {
+        return enif_make_tuple2(env, enif_make_atom(env, "error"), enif_make_atom(env, "close_execution_failed"));
+    }
+    
+    return enif_make_atom(env, "ok");
+}
+static ERL_NIF_TERM nif_run_inference(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+	DRV_DEBUG("Start to run_inference \n" );
+	LlamaContext* ctx;
+    unsigned long exec_ctx_id;
+    char *input = NULL;
+    tensor_data output;
+    ERL_NIF_TERM ret_term; // Variable for the return term
+    ERL_NIF_TERM result_bin;
+    uint32_t output_size = 0; // Initialize output_size
+
+    // Allocate memory
+    input = (char *)malloc(MAX_INPUT_SIZE * sizeof(char));
+    output = (uint8_t *)malloc(MAX_OUTPUT_SIZE * sizeof(uint8_t));
+    // Check allocations
+    if (!input || !output ) {
+        fprintf(stderr, "Initial memory allocation failed\n");
+        ret_term = enif_make_tuple2(env, enif_make_atom(env, "error"), enif_make_atom(env, "allocation_failed"));
+        goto cleanup; // Jump to cleanup section
+    }
+	// Get the context from the first argument
+	if (!enif_get_resource(env, argv[0], llama_context_resource, (void**)&ctx)) {
+        ret_term = enif_make_tuple2(env, enif_make_atom(env, "error"), enif_make_atom(env, "invalid_args"));
+        goto cleanup;
+    }
+    
+    // Get the execution context ID from the second argument
+    if (!enif_get_ulong(env, argv[1], &exec_ctx_id)) {
+        ret_term = enif_make_tuple2(env, enif_make_atom(env, "error"), enif_make_atom(env, "invalid_exec_ctx"));
+        goto cleanup;
+    }
+    
+	//Get input from the third argument
+	if (!enif_get_string(env, argv[2], input, MAX_INPUT_SIZE, ERL_NIF_LATIN1)) {
+		DRV_DEBUG("Invalid input\n");
+        ret_term = enif_make_tuple2(env, enif_make_atom(env, "error"), enif_make_atom(env, "invalid_input"));
+        goto cleanup;
+	}
+
+    tensor input_tensor = {
+		.dimensions = NULL,
+		.type =  fp32,
+        .data = (tensor_data)input,
+    };
+    // Run inference with session-specific execution context
+    if (g_wasi_nn_functions.run_inference(ctx->ctx, (graph_execution_context)exec_ctx_id, 0, &input_tensor, output, &output_size, NULL) != success) {
+        ret_term = enif_make_tuple2(env, enif_make_atom(env, "error"), enif_make_atom(env, "run_inference_failed"));
+        goto cleanup;
+    }
+	DRV_DEBUG("Output size: %d\n", output_size);
+	DRV_DEBUG("Output  %s\n", output);
+	// TODO limit output size
+    unsigned char* bin_data = enif_make_new_binary(env, output_size, &result_bin);
+    if (!bin_data) {
+        ret_term = enif_make_tuple2(env, enif_make_atom(env, "error"), enif_make_atom(env, "binary_creation_failed"));
+        // Output buffer still needs freeing in cleanup
+        goto cleanup;
+    }
+
+    // Copy the output_buffer into the Erlang binary
+    memcpy(bin_data, output, output_size);
+	ret_term = enif_make_tuple2(env, enif_make_atom(env, "ok"), result_bin);
+cleanup:
+    // Free all allocated memory. free(NULL) is safe.
+    free(input);
+    free(output);
+	DRV_DEBUG("Clean all");
+    return ret_term;
+}
+static ERL_NIF_TERM nif_set_input(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+	// TBD
+	return enif_make_atom(env, "ok");
+}
+static ERL_NIF_TERM nif_compute(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+	// TBD
+	return enif_make_atom(env, "ok");
+}
+static ERL_NIF_TERM nif_get_output(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+	// TBD
+	return enif_make_atom(env, "ok");
+}
+static ERL_NIF_TERM nif_deinit_backend(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    LlamaContext* ctx;
+    if (!enif_get_resource(env, argv[0], llama_context_resource, (void**)&ctx)) {
+        return enif_make_tuple2(env, enif_make_atom(env, "error"), enif_make_atom(env, "invalid_args"));
+    }
+    if (g_wasi_nn_functions.deinit_backend(ctx->ctx)!= success) {
+        return enif_make_tuple2(env, enif_make_atom(env, "error"), enif_make_atom(env, "deinit_failed"));
+    }
+    return enif_make_atom(env, "ok");
+}
+static ErlNifFunc nif_funcs[] = {
+    {"init_backend", 0, nif_init_backend},
+    {"load_by_name_with_config", 3, nif_load_by_name_with_config},
+    {"init_execution_context", 2, nif_init_execution_context},
+    {"close_execution_context", 2, nif_close_execution_context},
+	{"deinit_backend", 1, nif_deinit_backend},
+	{"run_inference", 3, nif_run_inference},
+};
+
+
+static void unload(ErlNifEnv* env, void* priv_data)
+{
+	// The resource destructor will be called automatically for any remaining resources
+	if (g_wasi_nn_functions.handle) {
+        dlclose(g_wasi_nn_functions.handle);
+        g_wasi_nn_functions.handle = NULL;
+	}
+}
+ERL_NIF_INIT(dev_wasi_nn_nif, nif_funcs, load, NULL, NULL, unload)

--- a/rebar.config
+++ b/rebar.config
@@ -52,6 +52,21 @@
             {add, cowboy, [{erl_opts, [{d, 'COWBOY_QUICER', 1}]}]},
             {add, gun, [{erl_opts, [{d, 'GUN_QUICER', 1}]}]}
         ]}
+    ]},
+    {wasi_nn, [
+        {erl_opts, [{d, 'ENABLE_WASI_NN', true}]},
+        {pre_hooks, [
+            {compile, "make -C \"${REBAR_ROOT_DIR}\" setup-wasi-nn"}
+        ]},
+        {port_specs, [
+            {"./priv/wasi_nn.so", [
+                "./native/wasi_nn_llama/src/wasi_nn_nif.c",
+                "./native/wasi_nn_llama/src/wasi_nn_logging.c"
+            ]}
+        ]},
+        {post_hooks, [
+            { compile, "rm -f native/wasi_nn_llama/src/*.o native/wasi_nn_llama/src/*.d"}
+        ]}
     ]}
 ]}.
 

--- a/src/dev_wasi_nn.erl
+++ b/src/dev_wasi_nn.erl
@@ -6,7 +6,6 @@
 -export([info/1, info/3, infer/3]).
 -include("include/hb.hrl").
 -include_lib("eunit/include/eunit.hrl").
--hb_debug(print).
 %% @doc Get device information and exported functions.
 %% Returns the list of functions that are exposed via the device API.
 %% This is used by the HyperBEAM runtime to determine which endpoints

--- a/src/dev_wasi_nn.erl
+++ b/src/dev_wasi_nn.erl
@@ -1,0 +1,254 @@
+%%% @doc A WASI-NN device implementation for HyperBEAM that provides AI inference
+%%% capabilities. This device supports loading models from Arweave transactions
+%%% and performing inference with session management for optimal performance.
+%%% Models are cached locally to avoid repeated downloads.
+-module(dev_wasi_nn).
+-export([info/1, info/3, infer/3]).
+-include("include/hb.hrl").
+
+%% @doc Get device information and exported functions.
+%% Returns the list of functions that are exposed via the device API.
+%% This is used by the HyperBEAM runtime to determine which endpoints
+%% are available for this device.
+%%
+%% @param _ Ignored parameter.
+%% @returns A map containing the list of exported functions.
+info(_) -> 
+    #{ exports => [info, infer] }.
+
+%% @doc Provide HTTP info response about this device.
+%% Returns comprehensive information about the WASI-NN device including
+%% its capabilities, version, and API documentation. This endpoint helps
+%% users understand how to interact with the AI inference functionality.
+%%
+%% @param _Msg1 Ignored parameter.
+%% @param _Msg2 Ignored parameter.
+%% @param _Opts Ignored parameter.
+%% @returns {ok, InfoBody} containing device information and API documentation.
+info(_Msg1, _Msg2, _Opts) ->
+    InfoBody = #{
+        <<"description">> => <<"GPU device for handling LLM Inference">>,
+        <<"version">> => <<"1.0">>,
+        <<"api">> => #{
+            <<"infer">> => #{
+                <<"description">> => <<"LLM Inference">>,
+                <<"method">> => <<"GET or POST">>,
+                <<"required_params">> => #{
+                    <<"prompt">> => <<"Prompt for Infer">>,
+                    <<"model-id">> => <<"Arweave TX ID of the model file">>
+                }
+            }
+        }
+    },
+    {ok, InfoBody}.
+
+%% @doc Perform AI inference using a specified model and prompt.
+%% This function handles the complete inference workflow including model
+%% retrieval (either from local cache or Arweave), session management,
+%% and inference execution. Models are automatically downloaded and cached
+%% locally for improved performance on subsequent requests.
+%%
+%% @param _M1 Ignored parameter.
+%% @param M2 The request message containing inference parameters:
+%%           - <<"model-id">>: Arweave transaction ID of the model file
+%%           - <<"config">>: JSON configuration for the model (optional)
+%%           - <<"prompt">>: The input prompt for inference
+%%           - <<"session-id">>: Session identifier for context reuse (optional)
+%% @param Opts A map of configuration options.
+%% @returns {ok, #{<<"result">> := Result, <<"session-id">> := SessionId}} on success,
+%%          {error, Reason} on failure.
+infer(_M1, M2, Opts) ->
+    TxID = hb_ao:get(<<"model-id">>, M2, undefined, Opts),
+    ModelConfig = hb_ao:get(<<"config">>, M2, 
+        "{\"n_gpu_layers\":96,\"ctx_size\":64000,\"batch_size\":64000}", Opts),
+    Prompt = hb_ao:get(<<"prompt">>, M2, Opts),
+    SessionId = hb_ao:get(<<"session-id">>, M2, undefined, Opts),
+    
+    ?event(dev_wasi_nn, {infer, {tx_id, TxID}, {session_id, SessionId}}),
+    
+    case TxID of
+        undefined ->
+            ?event(dev_wasi_nn, {infer, {fallback_to_default_model}}),
+            load_and_infer("models/qwen2.5-14b-instruct-q2_k.gguf", 
+                ModelConfig, Prompt, SessionId, Opts);
+        _ ->
+            ?event(dev_wasi_nn, {infer, {downloading_model, TxID}}),
+            case download_and_store_model(TxID, Opts) of
+                {ok, LocalModelPath} ->
+                    ?event(dev_wasi_nn, {infer, {model_ready, LocalModelPath}}),
+                    load_and_infer(LocalModelPath, ModelConfig, Prompt, SessionId, Opts);
+                {error, Reason} ->
+                    ?event(dev_wasi_nn, {infer, {model_download_failed, Reason}}),
+                    {error, {model_download_failed, Reason}}
+            end
+    end.
+
+%%%--------------------------------------------------------------------
+%%% Helper Functions
+%%%--------------------------------------------------------------------
+
+
+
+%% @doc Load model and perform inference using persistent context management.
+%% Handles the complete inference workflow including model loading, session
+%% management, and inference execution. Uses session IDs to maintain context
+%% across multiple requests for improved performance.
+%%
+%% @param ModelPath The local file path to the model.
+%% @param ModelConfig JSON configuration string for the model.
+%% @param Prompt The input prompt for inference.
+%% @param ProvidedSessionId Optional session ID for context reuse.
+%% @param Opts A map of configuration options.
+%% @returns {ok, #{<<"result">> := Result, <<"session-id">> := SessionId}} on success,
+%%          {error, Reason} on failure.
+load_and_infer(ModelPath, ModelConfig, Prompt, ProvidedSessionId, Opts) ->
+    SessionId = case ProvidedSessionId of
+        undefined -> generate_session_id(Opts);
+        _ -> binary_to_list(ProvidedSessionId)
+    end,
+    ?event(dev_wasi_nn, {load_and_infer, {model_path, ModelPath}, {session_id, SessionId}}),
+        % Use persistent context management (fast if model already loaded)
+    case dev_wasi_nn_nif:switch_model(ModelPath, ModelConfig) of
+        {ok, Context} ->
+            % Create or reuse session-specific execution context
+            case dev_wasi_nn_nif:init_execution_context_once(Context, SessionId) of
+                {ok, ExecContextId} ->
+                    % Run inference with session-specific context
+                    case dev_wasi_nn_nif:run_inference(Context, ExecContextId, binary_to_list(Prompt)) of
+                        {ok, Output} ->
+                            {ok, #{
+                                <<"result">> => hb_util:encode(Output),
+                                <<"session-id">> => list_to_binary(SessionId)
+                            }};
+                        {error, Reason} ->
+                            ?event(dev_wasi_nn, {inference_failed, SessionId, Reason}),
+                            {error, Reason}
+                    end;
+                {error, Reason2} ->
+                    ?event(dev_wasi_nn, {session_init_failed, SessionId, Reason2}),
+                    {error, Reason2}
+            end;
+        {error, Reason3} ->
+            ?event(dev_wasi_nn, {model_load_failed, SessionId, ModelPath, Reason3}),
+            {error, Reason3}
+    end.
+
+%% @doc Download model data from Arweave and store it locally.
+%% Helper function that handles the actual download and storage process
+%% when a model is not found in the local cache.
+%%
+%% @param TxID The Arweave transaction ID of the model.
+%% @param StoreConfig Configuration for the local storage.
+%% @param ModelFileName The filename to use for storing the model.
+%% @param LocalPath The full local path where the model will be stored.
+%% @returns {ok, LocalPath} on success, {error, Reason} on failure.
+download_model_from_arweave(TxID, StoreConfig, ModelFileName, LocalPath) ->
+    try
+        case hb_gateway_client:data(TxID, #{
+            http_connect_timeout => 10 * 60 * 1000
+        }) of
+            {ok, ModelData} ->
+                ?event(dev_wasi_nn, {download_model_from_arweave, {data_received, TxID}}),
+                case hb_store:write(StoreConfig, ModelFileName, ModelData) of
+                    ok ->
+                        ?event(dev_wasi_nn, {download_model_from_arweave, {model_stored, TxID, LocalPath}}),
+                        {ok, binary_to_list(LocalPath)};
+                    StoreError ->
+                        ?event(dev_wasi_nn, {download_model_from_arweave, {store_failed, TxID, StoreError}}),
+                        {error, {store_failed, StoreError}}
+                end;
+            {error, DownloadError} ->
+                ?event(dev_wasi_nn, {download_model_from_arweave, {download_failed, TxID, DownloadError}}),
+                {error, {download_failed, DownloadError}}
+        end
+    catch
+        Error:Reason ->
+            ?event(dev_wasi_nn, {download_model_from_arweave, {exception, TxID, Error, Reason}}),
+            {error, {exception, Error, Reason}}
+    end.
+%% @doc Download model from Arweave and store it locally.
+%% Attempts to retrieve a model file from local storage first, and if not found,
+%% downloads it from Arweave using the provided transaction ID. The model is
+%% stored locally with a .gguf extension for future use.
+%%
+%% @param TxID The Arweave transaction ID of the model file.
+%% @param Opts A map of configuration options (currently unused).
+%% @returns {ok, LocalPath} on success where LocalPath is the local file path,
+%%          {error, Reason} on failure.
+download_and_store_model(TxID, _Opts) ->
+    StoreConfig = #{
+        <<"store-module">> => hb_store_fs,
+        <<"name">> => <<"./models">>
+    },
+    ModelFileName = <<TxID/binary, ".gguf">>,
+    LocalPath = <<"./models/", ModelFileName/binary>>,
+    ?event(dev_wasi_nn, {download_and_store_model, {tx_id, TxID}, {local_path, LocalPath}}),
+    
+    case hb_store:read(StoreConfig, binary_to_list(ModelFileName)) of
+        {ok, _ExistingData} ->
+            ?event(dev_wasi_nn, {download_and_store_model, {model_already_exists, TxID}}),
+            {ok, binary_to_list(LocalPath)};
+        not_found ->
+            ?event(dev_wasi_nn, {download_and_store_model, {downloading_from_arweave, TxID}}),
+            download_model_from_arweave(TxID, StoreConfig, ModelFileName, LocalPath);
+        {error, ReadError} ->
+            ?event(dev_wasi_nn, {download_and_store_model, {read_error, TxID, ReadError}}),
+            download_model_from_arweave(TxID, StoreConfig, ModelFileName, LocalPath)
+    end.
+
+%% @doc Generate a unique session ID for inference requests.
+%% Creates a unique identifier combining timestamp, random number, and process
+%% information to ensure session uniqueness across concurrent requests.
+%%
+%% @param _Opts Configuration options (currently unused).
+%% @returns A string representing the unique session ID.
+generate_session_id(_Opts) ->
+    Timestamp = erlang:system_time(microsecond),
+    Random = rand:uniform(999999),
+    Pid = self(),
+    SessionId = io_lib:format("req_~p_~p_~p", [Timestamp, Random, Pid]),
+    lists:flatten(SessionId).
+
+cache_test_() ->
+    %% Start the HTTP server (required for gateway access)
+    hb_http_server:start_node(#{}),
+    %% Configure store with local caching
+    LocalStore = #{
+        <<"store-module">> => hb_store_fs,
+        <<"name">> => <<"model-cache">>
+    },
+    hb_store:reset(LocalStore),
+    Opts = #{
+        store => [
+            %% Try local cache first
+            LocalStore,
+            #{
+                <<"store-module">> => hb_store_gateway,
+                %% Cache results here
+                <<"local-store">> => LocalStore
+            }
+        ]
+    },
+
+    %% Read from Arweave
+    ID = <<"uJBApOt4ma3pTfY6Z4xmknz5vAasup4KcGX7FJ0Of8w">>,
+    case hb_cache:read(ID, Opts) of
+        {ok, Message} ->
+            ?event("Successfully read message from Arweave!~n"),
+
+            %% Validate the data content (similar to l1_transaction_test)
+            Data = maps:get(<<"data">>, Message),
+            ?assertEqual(<<"Hello World">>, Data),
+            ?event(cache, {hello_world_validation, Data}),
+            %% Subsequent reads will be from local cache
+            {ok, CachedMessage} = hb_cache:read(ID, #{store => [LocalStore]}),
+            io:format("Read from local cache: ~p~n", [CachedMessage]),
+
+            %% Validate cached data as well - need to resolve lazy links
+            FullyCachedMessage = hb_cache:ensure_all_loaded(CachedMessage, #{store => [LocalStore]}),
+            CachedData = maps:get(<<"data">>, FullyCachedMessage),
+            ?assertEqual(<<"Hello World">>, CachedData),
+            ?event(cache, {cached_hello_world_validation, CachedData});
+        not_found ->
+            ?event("Message not found on Arweave~n")
+    end.

--- a/src/dev_wasi_nn_nif.erl
+++ b/src/dev_wasi_nn_nif.erl
@@ -319,11 +319,11 @@ init_execution_context_once(Context, SessionId) ->
 
 %% @doc Test WASI-NN inference with a single model.
 %% This test validates the complete inference pipeline including model loading,
-%% session management, and inference execution. The test uses a pre-downloaded
-%% model file to avoid network dependencies during inference testing.
+%% session management, and inference execution. The test uses a model from Arweave
+%% to avoid network dependencies during inference testing.
 %%
 %% The test performs the following steps:
-%% 1. Loads a pre-downloaded model from local storage
+%% 1. Loads a  model from Arweave
 %% 2. Creates a model context using the NIF
 %% 3. Initializes an execution context for the session
 %% 4. Runs inference with a test prompt
@@ -333,9 +333,8 @@ init_execution_context_once(Context, SessionId) ->
 %% @returns ok on success, throws an error on failure.
 run_inference_test() ->    
     % Path to the pre-downloaded model file
-    % Note: This model should be downloaded first using dev_wasi_nn:model_download_test()
-    Path = "./models/ISrbGzQot05rs_HKC08O_SmkipYQnqgB1yC3mjZZeEo.gguf",
-    
+    {ok, Path} = dev_wasi_nn:read_model_by_ID("ISrbGzQot05rs_HKC08O_SmkipYQnqgB1yC3mjZZeEo"),
+    ?event(dev_wasi_nn_nif, {model_path, Path}),
     % Model configuration for GPU inference
     % - n_gpu_layers: Number of layers to offload to GPU
     % - ctx_size: Context window size for the model
@@ -348,7 +347,7 @@ run_inference_test() ->
     SessionId = "test_session_1",
     
     % Test prompt for inference
-    Prompt = "What is the meaning of life",
+    Prompt = "Who are you ?",
     
     % Step 1: Load the model and create a context
     % This will either create a new context or reuse an existing one

--- a/src/dev_wasi_nn_nif.erl
+++ b/src/dev_wasi_nn_nif.erl
@@ -1,0 +1,358 @@
+%%% @doc WASI-NN NIF module for HyperBEAM.
+%%% Implements native functions for AI model loading and inference.
+%%% This module provides the NIF interface for the dev_wasi_nn module.
+-module(dev_wasi_nn_nif).
+-include("include/hb.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-export([
+    init_backend/0,
+    load_by_name_with_config/3,
+    init_execution_context/2,
+    close_execution_context/2,
+    deinit_backend/1,
+    run_inference/3
+]).
+-export([init_execution_context_once/2, switch_model/2]).
+-export([cleanup_model_contexts/1, cleanup_all_contexts/0, get_current_model_info/0]).
+
+-on_load(init/0).
+-define(NOT_LOADED, not_loaded(?LINE)).
+
+%% Module-level cache
+-define(CACHE_TAB, wasi_nn_cache).
+-define(SINGLETON_KEY, global_cache).
+-define(CACHE_OWNER_NAME, wasi_nn_cache_owner).  % Registered name for cache owner process
+
+%% @doc Start the dedicated ETS table owner process.
+%% Creates a persistent process that owns the ETS table to ensure it remains
+%% available even if the calling process terminates.
+%%
+%% @returns {ok, Pid} where Pid is the process ID of the cache owner.
+start_cache_owner() ->
+    case whereis(?CACHE_OWNER_NAME) of
+        undefined ->
+            % No owner process exists, create one
+            Pid = spawn(fun() -> 
+                % Create the table if it doesn't exist
+                case ets:info(?CACHE_TAB) of
+                    undefined ->
+                        ?event(dev_wasi_nn_nif, {cache_owner_creating_table, ?CACHE_TAB}),
+                        ets:new(?CACHE_TAB, [set, named_table, public]);
+                    _ ->
+                        ?event(dev_wasi_nn_nif, {cache_table_already_exists, ?CACHE_TAB})
+                end,
+                % Register the process with a name for easy lookup
+                register(?CACHE_OWNER_NAME, self()),
+                cache_owner_loop()
+            end),
+            {ok, Pid};
+        Pid ->
+            % Owner process already exists
+            {ok, Pid}
+    end.
+
+%% @doc Loop function for the cache owner process.
+%% Keeps the process alive to maintain ownership of the ETS table.
+%% Handles stop messages and ping requests.
+%%
+%% @returns ok when the process is stopped.
+cache_owner_loop() ->
+    receive
+        stop -> 
+            ?event(dev_wasi_nn_nif, {cache_owner_stopping}),
+            ok;
+        {From, ping} ->
+            From ! {self(), pong},
+            cache_owner_loop();
+        _ -> 
+            cache_owner_loop()
+    after 
+        3600000 -> % Stay alive for a long time (1 hour), then check again
+            cache_owner_loop()
+    end.
+
+%% Initialize the NIF library and cache management
+init() ->
+    PrivDir = code:priv_dir(hb),
+    Path = filename:join(PrivDir, "wasi_nn"),
+    ?event(dev_wasi_nn_nif, {loading_nif_from, Path}),
+    
+    % Start the dedicated cache owner process
+    start_cache_owner(),
+    
+    % Load the NIF library
+    case erlang:load_nif(Path, 0) of
+        ok ->
+            ?event(dev_wasi_nn_nif, {nif_loaded_successfully}),
+            ok;
+        {error, {load_failed, Reason}} ->
+            ?event(dev_wasi_nn_nif, {failed_to_load_nif, Reason}),
+            exit({load_failed, {load_failed, Reason}});
+        {error, Reason} ->
+            ?event(dev_wasi_nn_nif, {failed_to_load_nif_with_error, Reason}),
+            exit({load_failed, Reason})
+    end.
+
+%% Error handler for NIF functions that are not loaded
+not_loaded(Line) ->
+    erlang:nif_error({not_loaded, [{module, ?MODULE}, {line, Line}]}).
+
+init_backend() ->
+    ?NOT_LOADED.
+
+load_by_name_with_config(_Context, _Path, _Config) ->
+    ?NOT_LOADED.
+
+init_execution_context(_Context, _SessionId) ->
+    ?NOT_LOADED.
+
+close_execution_context(_Context, _ExecContextId) ->
+    ?NOT_LOADED.
+
+% set_input(_Context, _Prompt) ->
+%     erlang:nif_error("NIF library not loaded").
+
+% compute(_Context) ->
+%     erlang:nif_error("NIF library not loaded").
+% get_output(_Context) ->
+%     erlang:nif_error("NIF library not loaded").
+deinit_backend(_Context) ->
+    ?NOT_LOADED.
+run_inference(_Context, _ExecContextId, _Prompt) ->
+    ?NOT_LOADED.
+
+%% ============================================================================
+%% GLOBAL PERSISTENT CONTEXT MANAGEMENT
+%% ============================================================================
+
+%% @doc Switch to a different model, creating a new context for each model.
+%% Checks if the model is already loaded with the same configuration,
+%% and reuses the existing context if possible. Otherwise, creates a new context.
+%%
+%% @param ModelPath Path to the model file.
+%% @param Config Configuration for the model.
+%% @returns {ok, Context} on success, {error, Reason} on failure.
+switch_model(ModelPath, Config) ->
+    ensure_cache_table(),
+    ModelKey = {?SINGLETON_KEY, model_context, ModelPath},
+    
+    case ets:lookup(?CACHE_TAB, ModelKey) of
+        [{_, {ok, Context, CachedConfig}}] when CachedConfig =:= Config ->
+            ?event(dev_wasi_nn_nif, {model_already_loaded, ModelPath, reusing_context}),
+            % Update current model reference
+            ets:insert(?CACHE_TAB, {{?SINGLETON_KEY, current_model}, {ModelPath, Config, Context}}),
+            {ok, Context};
+        [{_, {ok, OldContext, _OldConfig}}] ->
+            ?event(dev_wasi_nn_nif, {model_different_config, ModelPath, reinitializing}),
+            % Cleanup old context for this model
+            deinit_backend(OldContext),
+            % Create new context for this model
+            create_model_context(ModelPath, Config);
+        [] ->
+            ?event(dev_wasi_nn_nif, {model_not_loaded, ModelPath, creating_new_context}),
+            create_model_context(ModelPath, Config)
+    end.
+
+%% @doc Create a new model context.
+%% Initializes a new backend context and loads the model.
+%%
+%% @param ModelPath Path to the model file.
+%% @param Config Configuration for the model.
+%% @returns {ok, Context} on success, {error, Reason} on failure.
+create_model_context(ModelPath, Config) ->
+    ensure_cache_table(),
+    ModelKey = {?SINGLETON_KEY, global_backend, ModelPath},
+    
+    % Get or create the global backend context for this model
+    case ets:lookup(?CACHE_TAB, ModelKey) of
+        [{_, {ok, Context}}] ->
+            ?event(dev_wasi_nn_nif, {using_existing_global_backend, ModelPath}),
+            load_model_with_context(Context, ModelPath, Config);
+        [] ->
+            ?event(dev_wasi_nn_nif, {creating_new_global_backend, ModelPath}),
+            case init_backend() of
+                {ok, Context} ->
+                    ets:insert(?CACHE_TAB, {ModelKey, {ok, Context}}),
+                    ?event(dev_wasi_nn_nif, {global_backend_created, ModelPath}),
+                    load_model_with_context(Context, ModelPath, Config);
+                Error ->
+                    ?event(dev_wasi_nn_nif, {failed_to_create_global_backend, ModelPath, Error}),
+                    Error
+            end
+    end.
+
+%% @doc Load a model with an existing context.
+%% Uses an existing backend context to load a model.
+%%
+%% @param Context The backend context.
+%% @param ModelPath Path to the model file.
+%% @param Config Configuration for the model.
+%% @returns {ok, Context} on success, {error, Reason} on failure.
+load_model_with_context(Context, ModelPath, Config) ->
+    case load_by_name_with_config(Context, ModelPath, Config) of
+        ok ->
+            ModelKey = {?SINGLETON_KEY, model_context, ModelPath},
+            ets:insert(?CACHE_TAB, {ModelKey, {ok, Context, Config}}),
+            ets:insert(?CACHE_TAB, {{?SINGLETON_KEY, current_model}, {ModelPath, Config, Context}}),
+            ?event(dev_wasi_nn_nif, {model_context_created, ModelPath}),
+            {ok, Context};
+        Error ->
+            ?event(dev_wasi_nn_nif, {failed_to_load_model, ModelPath, Error}),
+            % Cleanup the backend context since model loading failed
+            deinit_backend(Context),
+            ets:delete(?CACHE_TAB, {?SINGLETON_KEY, global_backend, ModelPath}),
+            {error, {model_load_failed, Error}}
+    end.
+
+%% @doc Get information about the currently loaded model.
+%% Retrieves the model path, configuration, and context for the currently loaded model.
+%%
+%% @returns {ok, {ModelPath, Config, Context}} on success,
+%%          {error, no_model_loaded} if no model is loaded.
+get_current_model_info() ->
+    ensure_cache_table(),
+    case ets:lookup(?CACHE_TAB, {?SINGLETON_KEY, current_model}) of
+        [{_, {ModelPath, Config, Context}}] -> {ok, {ModelPath, Config, Context}};
+        [] -> {error, no_model_loaded}
+    end.
+
+%% @doc Clean up all contexts for a specific model.
+%% Removes all execution contexts and the model context for a specific model.
+%%
+%% @param ModelPath Path to the model file.
+%% @returns ok.
+cleanup_model_contexts(ModelPath) ->
+    ensure_cache_table(),
+    % Clean up all execution contexts for this model
+    ets:match_delete(?CACHE_TAB, {{?SINGLETON_KEY, context_initialized, ModelPath, '_'}, '_'}),
+    % Clean up the model context
+    case ets:lookup(?CACHE_TAB, {?SINGLETON_KEY, model_context, ModelPath}) of
+        [{_, {ok, Context, _Config}}] ->
+            deinit_backend(Context),
+            ets:delete(?CACHE_TAB, {?SINGLETON_KEY, model_context, ModelPath}),
+            ets:delete(?CACHE_TAB, {?SINGLETON_KEY, global_backend, ModelPath}),
+            ?event(dev_wasi_nn_nif, {cleaned_up_contexts, ModelPath}),
+            ok;
+        [] ->
+            ?event(dev_wasi_nn_nif, {no_context_to_cleanup, ModelPath}),
+            ok
+    end.
+
+%% @doc Clean up all cached contexts.
+%% Removes all model contexts and execution contexts from the cache.
+%% Useful for testing or memory management.
+%%
+%% @returns ok.
+cleanup_all_contexts() ->
+    ensure_cache_table(),
+    % Get all model contexts and clean them up
+    ModelContexts = ets:match(?CACHE_TAB, {{?SINGLETON_KEY, model_context, '$1'}, {ok, '$2', '$3'}}),
+    lists:foreach(fun([ModelPath, Context, _Config]) ->
+        deinit_backend(Context),
+        ?event(dev_wasi_nn_nif, {cleaned_up_context, ModelPath})
+    end, ModelContexts),
+    % Clear the entire cache
+    ets:delete_all_objects(?CACHE_TAB),
+    ?event(dev_wasi_nn_nif, {all_contexts_cleaned_up}),
+    ok.
+
+%% @doc Helper function to safely access the ETS table.
+%% Ensures that the ETS table exists and has an owner process.
+%% If the table doesn't exist, it starts the cache owner process.
+%% If the table exists but has no owner, it restarts the owner process.
+%%
+%% @returns ok if the table exists and has an owner,
+%%          {ok, Pid} if a new owner process was started.
+ensure_cache_table() ->
+    case ets:info(?CACHE_TAB) of
+        undefined ->
+            % Start the cache owner which will create the table
+            ?event(dev_wasi_nn_nif, {table_doesnt_exist, starting_cache_owner}),
+            start_cache_owner();
+        _ ->
+            % Table exists, ensure owner process is running
+            case whereis(?CACHE_OWNER_NAME) of
+                undefined ->
+                    % Strange case: table exists but no owner - restart owner
+                    ?event(dev_wasi_nn_nif, {table_exists_no_owner, restarting_owner}),
+                    start_cache_owner();
+                _ ->
+                    % All good, table exists and owner is running
+                    ok
+            end
+    end.
+
+%% @doc Function to ensure execution context is only initialized once per session and model.
+%% Checks if an execution context already exists for the given session and model,
+%% and reuses it if possible. Otherwise, creates a new execution context.
+%%
+%% @param Context The model context.
+%% @param SessionId The session identifier.
+%% @returns {ok, ExecContextId} on success, {error, Reason} on failure.
+init_execution_context_once(Context, SessionId) ->
+    ensure_cache_table(),
+    % Get current model info to create a unique session key per model
+    case get_current_model_info() of
+        {ok, {ModelPath, _Config, _Context}} ->
+            SessionKey = {?SINGLETON_KEY, context_initialized, ModelPath, SessionId},
+            case ets:lookup(?CACHE_TAB, SessionKey) of
+                [{_, {ok, ExecContextId}}] ->
+                    ?event(dev_wasi_nn_nif, {execution_context_already_initialized, SessionId, ModelPath}),
+                    {ok, ExecContextId};
+                [] ->
+                    Result = init_execution_context(Context, SessionId),
+                    case Result of
+                        {ok, ExecContextId} ->
+                            ets:insert(?CACHE_TAB, {SessionKey, {ok, ExecContextId}}),
+                            ?event(dev_wasi_nn_nif, {execution_context_initialized, SessionId, ModelPath}),
+                            {ok, ExecContextId};
+                        Error ->
+                            ?event(dev_wasi_nn_nif, {failed_to_initialize_execution_context, SessionId, ModelPath, Error}),
+                            Error
+                    end
+            end;
+        {error, no_model_loaded} ->
+            ?event(dev_wasi_nn_nif, {no_model_loaded, cannot_initialize_execution_context}),
+            {error, no_model_loaded}
+    end.
+
+run_inference_test() ->
+    Path = "models/qwen2.5-14b-instruct-q2_k.gguf",
+    Path2 = "models/ISrbGzQot05rs_HKC08O_SmkipYQnqgB1yC3mjZZeEo.gguf",
+    Config =
+        "{\"n_gpu_layers\":98,\"ctx_size\":2048,\"stream-stdout\":true,\"enable_debug_log\":true}",
+    SessionId = "test_session_1",
+    Prompt1 = "What is the meaning of life",
+    
+    % Test 1: Load first model (should create new context)
+    {ok, Context1} = switch_model(Path, Config),
+    ?event(dev_wasi_nn_nif, {model_loaded, Context1, Path, Config}),
+    
+    % Test 2: Create session and run inference
+    {ok, ExecContextId1} = init_execution_context_once(Context1, SessionId),
+    {ok, Output1} = run_inference(Context1, ExecContextId1, Prompt1),
+    ?event(dev_wasi_nn_nif, {run_inference, Context1, ExecContextId1, Prompt1, Output1}),
+    ?assertNotEqual(Output1, ""),
+    
+    % Test 3: Switch to same model (should reuse context)
+    StartTime = erlang:system_time(millisecond),
+    {ok, Context1_reused} = switch_model(Path, Config),
+    EndTime = erlang:system_time(millisecond),
+    ReuseDuration = EndTime - StartTime,
+    ?event(dev_wasi_nn_nif, {context_reuse, ReuseDuration}),
+    ?assert(ReuseDuration < 100), % Should be nearly instant
+    ?assertEqual(Context1, Context1_reused), % Should be the same context
+    {ok, Output2} = run_inference(Context1_reused, ExecContextId1, "Who are you?"),
+    ?event(dev_wasi_nn_nif, {run_inference, Context1, ExecContextId1, "Who are you?", Output2}),
+    
+    % Test 9: Try to switch to cleaned up model (should create new context)
+    {ok, Context2_new} = switch_model(Path2, Config),
+    {ok, ExecContextId3} = init_execution_context_once(Context2_new, "test_session_2"),
+    {ok, Output3} = run_inference(Context2_new, ExecContextId3, Prompt1),
+    ?event(dev_wasi_nn_nif, {run_inference, Context2_new, ExecContextId3, Prompt1, Output3}),
+    ?assertNotEqual(Output3, ""),
+    ?assertNotEqual(Context1, Context2_new), % Should be a new context
+    
+    % Cleanup all contexts
+    cleanup_all_contexts().

--- a/src/dev_wasi_nn_nif.erl
+++ b/src/dev_wasi_nn_nif.erl
@@ -318,7 +318,7 @@ init_execution_context_once(Context, SessionId) ->
     end.
 
 run_inference_test() ->
-    Path = "models/qwen2.5-14b-instruct-q2_k.gguf",
+    Path = "model-cache/XOJ8FBxa6sGLwChnxhF2L71WkKLSKq1aU5Yn5WnFLrY",
     Path2 = "models/ISrbGzQot05rs_HKC08O_SmkipYQnqgB1yC3mjZZeEo.gguf",
     Config =
         "{\"n_gpu_layers\":98,\"ctx_size\":2048,\"stream-stdout\":true,\"enable_debug_log\":true}",


### PR DESCRIPTION
## Summary
This PR introduces the WASI-NN Device (dev_wasi_nn). The device provides AI inference capabilities for HyperBEAM, supporting loading models from Arweave transactions and performing inference with session management for optimal performance. It provides an Erlang interface for AI model inference, leveraging a NIF backend for the actual inference logic and automatic model caching to avoid repeated downloads.
## Key features:
- GPU powered AI LLM inference 
- Automatic model download and caching from Arweave
- Session management for context reuse across multiple requests
- Persistent context management for improved performance
- Robust error handling for network issues, model loading failures, and inference errors
- Unit tests for both model download and inference flows
## API Endpoints
`GET /~wasi-nn@1.0/infer`
- Description: Performs AI inference using a specified model and prompt.
- Parameters:
    - model-id : Arweave transaction ID of the model file. If not provided, uses a default model.
    - prompt (required): The input text for inference.
- Returns: {ok, #{<<"result">> := Result, <<"session-id">> := SessionId}} on success, or {error, Reason} on failure.
## Setup Environment
-  **rebar3 as wasi_nn shell** 
## File Change Description
- **dev_wasi_nn.erl** : main device code for HB
- **dev_wasi_nn_nif.erl** : NIF code for calling native implmentaion in C
- **rebar3.config & Makefile** : add profiles for device wasi_nn -> rebar3 as wasi_nn shell
- **native/wasi_nn_llama** : native implementation with wasi_nn & llamacpp backend
## Models
- Current tested stable model on Arweave is : **Phi-3 Mini 4k Instruct** ,"ISrbGzQot05rs_HKC08O_SmkipYQnqgB1yC3mjZZeEo" 
- Not support old models like  Phi-2 or  GPT-2 
- You can download latest models in local and using hb_store_fs to load model
## Unit test
- dev_wasi_nn : 
    - read_model_by_ID_test : Return model file path , If not exist , download Phi-3 Mini 4k Instruct from arweave, remeber to setup longer HTTP timeout
    - infer_test : API end point  unit test
    
<img width="1352" height="180" alt="image" src="https://github.com/user-attachments/assets/9ca3afe7-25cd-40ad-a8d6-adbdc1814f6d" />

- dev_wasi_nn_nif : **run_inference_test** -> one round for inference call 
<img width="1281" height="312" alt="nif" src="https://github.com/user-attachments/assets/96d83e13-f698-4372-b722-174f370fb5fd" />


**During call this device , logs will show using cuda for inference** 
<img width="1221" height="579" alt="nn2" src="https://github.com/user-attachments/assets/523f27f2-ace3-43f6-9b5b-ebaa0141c78a" />

